### PR TITLE
Improvements to autocombinerewards

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -60,7 +60,7 @@ static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** Default for accepting alerts from the P2P network. */
 static const bool DEFAULT_ALERTS = true;
 /** The maximum size for transactions we're willing to relay/mine */
-static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
+static const unsigned int MAX_STANDARD_TX_SIZE = 250000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE / 50;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3328,7 +3328,8 @@ void CWallet::AutoCombineDust()
             nTotalRewardsValue += out.Value();
 
             // Combine to the threshold and not way above
-            if (nTotalRewardsValue > nAutoCombineThreshold * COIN)
+            // make sure we will still be above the threshold when we reduce 10%  
+            if ((nTotalRewardsValue-nTotalRewardsValue/10) > nAutoCombineThreshold * COIN)
                 break;
 
             // Around 180 bytes per input.  We use 190 to be certain
@@ -3374,7 +3375,8 @@ void CWallet::AutoCombineDust()
         }
 
         //we don't combine below the threshold unless the fees are 0 to avoid paying fees over fees over fees
-        if (!maxSize && nTotalRewardsValue < nAutoCombineThreshold * COIN && nFeeRet > 0)
+        // Don't pass this on one that was above threshold here, but then below threshold after the 10% reduce
+        if (!maxSize && (nTotalRewardsValue-nTotalRewardsValue/10) < nAutoCombineThreshold * COIN && nFeeRet > 0)
             continue;
 
         if (!CommitTransaction(wtx, keyChange)) {
@@ -3382,7 +3384,8 @@ void CWallet::AutoCombineDust()
             continue;
         }
 
-        LogPrintf("AutoCombineDust sent transaction\n");
+        LogPrintf("AutoCombineDust sent transaction. Fee=%d, Total Value=%d Sending=%d\n",
+                  nFeeRet, nTotalRewardsValue, vecSend[0].second);
 
         delete coinControl;
     }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3294,32 +3294,49 @@ bool CWallet::GetDestData(const CTxDestination& dest, const std::string& key, st
 
 void CWallet::AutoCombineDust()
 {
-    if (IsInitialBlockDownload() || IsLocked()) {
+    LOCK2(cs_main, cs_wallet);
+    // Stop the old blocks from sending multisends
+    if (chainActive.Tip()->nTime < (GetAdjustedTime() - 300) || IsLocked()) {
         return;
     }
 
-    map<CBitcoinAddress, vector<COutput> > mapCoinsByAddress = AvailableCoinsByAddress(true, 0);
+    map<CBitcoinAddress, vector<COutput> > mapCoinsByAddress = AvailableCoinsByAddress(true, nAutoCombineThreshold * COIN);
 
     //coins are sectioned by address. This combination code only wants to combine inputs that belong to the same address
     for (map<CBitcoinAddress, vector<COutput> >::iterator it = mapCoinsByAddress.begin(); it != mapCoinsByAddress.end(); it++) {
         vector<COutput> vCoins, vRewardCoins;
+	bool maxSize = false;    
         vCoins = it->second;
+
+        // We don't want the tx to be refused for being too large
+        // we use 50 bytes as a base tx size (2 output: 2*34 + overhead: 10 -> 90 to be certain)
+        unsigned int txSizeEstimate = 90;
 
         //find masternode rewards that need to be combined
         CCoinControl* coinControl = new CCoinControl();
         CAmount nTotalRewardsValue = 0;
         BOOST_FOREACH (const COutput& out, vCoins) {
+            if (!out.fSpendable)
+                continue;
             //no coins should get this far if they dont have proper maturity, this is double checking
             if (out.tx->IsCoinStake() && out.tx->GetDepthInMainChain() < COINBASE_MATURITY + 1)
-                continue;
-
-            if (out.Value() > nAutoCombineThreshold * COIN)
                 continue;
 
             COutPoint outpt(out.tx->GetHash(), out.i);
             coinControl->Select(outpt);
             vRewardCoins.push_back(out);
             nTotalRewardsValue += out.Value();
+
+            // Combine to the threshold and not way above
+            if (nTotalRewardsValue > nAutoCombineThreshold * COIN)
+                break;
+
+            // Around 180 bytes per input.  We use 190 to be certain
+            txSizeEstimate += 190;
+            if (txSizeEstimate >= MAX_STANDARD_TX_SIZE - 200) {
+                maxSize = true;
+                break;
+	    }            
         }
 
         //if no inputs found then return
@@ -3334,21 +3351,31 @@ void CWallet::AutoCombineDust()
         CScript scriptPubKey = GetScriptForDestination(it->first.Get());
         vecSend.push_back(make_pair(scriptPubKey, nTotalRewardsValue));
 
-        // Create the transaction and commit it to the network
+        //Send change to same address
+        CTxDestination destMyAddress;
+        if (!ExtractDestination(scriptPubKey, destMyAddress)) {
+            LogPrintf("AutoCombineDust: failed to extract destination\n");
+            continue;
+        }
+        coinControl->destChange = destMyAddress;
+
+	// Create the transaction and commit it to the network
         CWalletTx wtx;
         CReserveKey keyChange(this); // this change address does not end up being used, because change is returned with coin control switch
         string strErr;
         CAmount nFeeRet = 0;
 
-        //get the fee amount
-        CWalletTx wtxdummy;
-        CreateTransaction(vecSend, wtxdummy, keyChange, nFeeRet, strErr, coinControl, ALL_COINS, false, CAmount(0));
-        vecSend[0].second = nTotalRewardsValue - nFeeRet - 500;
+        // 10% safety margin to avoid "Insufficient funds" errors
+        vecSend[0].second = nTotalRewardsValue - (nTotalRewardsValue / 10);
 
         if (!CreateTransaction(vecSend, wtx, keyChange, nFeeRet, strErr, coinControl, ALL_COINS, false, CAmount(0))) {
             LogPrintf("AutoCombineDust createtransaction failed, reason: %s\n", strErr);
             continue;
         }
+
+        //we don't combine below the threshold unless the fees are 0 to avoid paying fees over fees over fees
+        if (!maxSize && nTotalRewardsValue < nAutoCombineThreshold * COIN && nFeeRet > 0)
+            continue;
 
         if (!CommitTransaction(wtx, keyChange)) {
             LogPrintf("AutoCombineDust transaction commit failed\n");


### PR DESCRIPTION
autocombinerewards functions as is, but is virtually unusable; It sweeps up every reward received and sends it back out, like rolling a snowball, until the threshold value is met.  

Several changes were made in the pivx source;

- #488 - Fix bug when autocombinerewards is enabled on a wallet with many transactions, and/or the threshold is set high enough that the generated transaction exceeds max size.
- #497 - Reduce frequency of calls to auto combine dust.  Only combine the threshold size, and not a huge amount more.  Unless fees are zero, don't combine until there's enough to meet the threshold.  
- #518 - Send change to the same address and add some buffer to prevent insufficient funds.
- #625 - Crash prevention tweak
- #700 - Fix for 497 to prevent the condition where the threshold is too high to reach without exceeding the max size.

These make the feature virtually usable. It only 'snowballs' the rewards one by one if there is no transaction fee.  Otherwise it waits until it's collected up enough to meet the threshold.  Upon testing however, there was still a logical flaw introduced with the #518, which reduced the rolled up dust ball by 10% to cover insufficient funds (90% of the ball for the combine tx, 10% of the ball for the fees etc).  (that code doesn't sit right for other reasons either, but that's for another day).

The logical flaw is seen in two places.  First, if the collection of dust exceeds the threshold, it would continue on and eventually roll up the transaction.  However if that collection was less than 10% over the threshold, and then the tx broken up to 90% with 10% change; those two pieces would be collected again the next time around... thus causing it to repetitively send that transaction until fees widdle it back below.  We do not want to break out of the dust cleanup loop until we have collected enough so that the 10% reduced tx exceeds the threshold.

Secondly, if the situation occurs where the total amount of dust (we exhaust the dust collection loop), and are right on that threshold edge; the below threshold, 0 fee, check should have thrown it out; but it sees it's over threshold.... and we end up again repetitively combining the tx and change until we've widdled down to below the threshold.

This is tested and appears to work as expected. 