### PR TITLE
AutoCombineDust Frequency

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -104,6 +104,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     {"setstakesplitthreshold", 0},
     {"autocombinerewards", 0},
     {"autocombinerewards", 1},
+    {"autocombinerewards", 2},
     {"obfuscation", 1},
 };
 

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2017 The PIVX developers
 // Copyright (c) 2017-2018 The XDNA Core developers
+// Copyright (c) 2018-2019 The United Community Coin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -363,6 +363,7 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "getreceivedbyaddress", &getreceivedbyaddress, false, false, true},
         {"wallet", "getstakingstatus", &getstakingstatus, false, false, true},
         {"wallet", "getstakesplitthreshold", &getstakesplitthreshold, false, false, true},
+  		  {"wallet", "getautocombineinfo", &getautocombineinfo, false, false, true},
         {"wallet", "gettransaction", &gettransaction, false, false, true},
         {"wallet", "getunconfirmedbalance", &getunconfirmedbalance, false, false, true},
         {"wallet", "getwalletinfo", &getwalletinfo, false, false, true},

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2017 The PIVX developers
 // Copyright (c) 2017-2018 The XDNA Core developers
+// Copyright (c) 2018-2019 The United Community Coin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -364,7 +364,7 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "getreceivedbyaddress", &getreceivedbyaddress, false, false, true},
         {"wallet", "getstakingstatus", &getstakingstatus, false, false, true},
         {"wallet", "getstakesplitthreshold", &getstakesplitthreshold, false, false, true},
-  		  {"wallet", "getautocombineinfo", &getautocombineinfo, false, false, true},
+        {"wallet", "getautocombineinfo", &getautocombineinfo, false, false, true},
         {"wallet", "gettransaction", &gettransaction, false, false, true},
         {"wallet", "getunconfirmedbalance", &getunconfirmedbalance, false, false, true},
         {"wallet", "getwalletinfo", &getwalletinfo, false, false, true},

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2009-2014 The Bitcoin developers
 // Copyright (c) 2015-2017 The PIVX developers
 // Copyright (c) 2017-2018 The XDNA Core developers
+// Copyright (c) 2018-2019 The United Community Coin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -214,6 +214,7 @@ extern UniValue reservebalance(const UniValue& params, bool fHelp);
 extern UniValue setstakesplitthreshold(const UniValue& params, bool fHelp);
 extern UniValue getstakesplitthreshold(const UniValue& params, bool fHelp);
 extern UniValue multisend(const UniValue& params, bool fHelp);
+extern UniValue getautocombineinfo(const UniValue& params, bool fHelp);
 extern UniValue autocombinerewards(const UniValue& params, bool fHelp);
 
 extern UniValue getrawtransaction(const UniValue& params, bool fHelp); // in rcprawtransaction.cpp

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2040,21 +2040,23 @@ UniValue getstakesplitthreshold(const UniValue& params, bool fHelp)
     return int(pwalletMain->nStakeSplitThreshold);
 }
 
-UniValue getautocombineinfo(const Array& params, bool fHelp)
+UniValue getautocombineinfo(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
             "getautocombineinfo\n"
             "Returns the autocombinerewards settings\n");
 
-    Object result;
-	result.push_back(Pair("autocombine set to <on/off>  ", int(pwalletMain->fCombineDust)));
+    UniValue obj(UniValue::VOBJ);
+    obj.push_back(Pair("autocombine set to <on/off>  ", int(pwalletMain->fCombineDust)));
     if (pwalletMain->fCombineDust) {
-        result.push_back(Pair("autocombine threshold set to <Coin Amount>", int(pwalletMain->nAutoCombineThreshold)));
-        result.push_back(Pair("autocombine block frequency set to ", int(pwalletMain->nAutoCombineBlockFrequency)));
+        obj.push_back(Pair("autocombine threshold set to <Coin Amount>", 
+                            int(pwalletMain->nAutoCombineThreshold)));
+        obj.push_back(Pair("autocombine block frequency set to ", 
+                            int(pwalletMain->nAutoCombineBlockFrequency)));
     }
     
-    return result;
+    return obj;
 }
 
 UniValue autocombinerewards(const UniValue& params, bool fHelp)
@@ -2091,19 +2093,25 @@ UniValue autocombinerewards(const UniValue& params, bool fHelp)
             if (nBlockFrequency < 1)
                 nBlockFrequency = 1;
         }
-	}
+    }
 
     pwalletMain->fCombineDust = fEnable;
     pwalletMain->nAutoCombineThreshold = nThreshold;
-	pwalletMain->nAutoCombineBlockFrequency = nAutoCombineBlockFrequency;			
+    pwalletMain->nAutoCombineBlockFrequency = nBlockFrequency;
 
     if (!walletdb.WriteAutoCombineSettings(fEnable, nThreshold, nBlockFrequency))
         throw runtime_error("Changed settings in wallet but failed to save to database\n");
 
-    if (fEnable)
-        return "Auto Combine Rewards Enabled.  Threshold: " << nThreshold << " Frequency: " << nBlockFrequency << " Blocks";
-    else
-        return "Auto Combine Rewards Disabled";
+    UniValue obj(UniValue::VOBJ);
+    obj.push_back(Pair("autocombine set to <on/off>  ", int(pwalletMain->fCombineDust)));
+    if (pwalletMain->fCombineDust) {
+        obj.push_back(Pair("autocombine threshold set to <Coin Amount>", 
+                            int(pwalletMain->nAutoCombineThreshold)));
+        obj.push_back(Pair("autocombine block frequency set to ", 
+                            int(pwalletMain->nAutoCombineBlockFrequency)));
+    }
+    
+    return obj;
 }
 
 UniValue printMultiSend()

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2017 The PIVX developers
 // Copyright (c) 2017-2018 The XDNA Core developers
+// Copyright (c) 2018-2019 The United Community Coin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -2039,37 +2040,70 @@ UniValue getstakesplitthreshold(const UniValue& params, bool fHelp)
     return int(pwalletMain->nStakeSplitThreshold);
 }
 
+UniValue getautocombineinfo(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "getautocombineinfo\n"
+            "Returns the autocombinerewards settings\n");
+
+    Object result;
+	result.push_back(Pair("autocombine set to <on/off>  ", int(pwalletMain->fCombineDust)));
+    if (pwalletMain->fCombineDust) {
+        result.push_back(Pair("autocombine threshold set to <Coin Amount>", int(pwalletMain->nAutoCombineThreshold)));
+        result.push_back(Pair("autocombine block frequency set to ", int(pwalletMain->nAutoCombineBlockFrequency)));
+    }
+    
+    return result;
+}
+
 UniValue autocombinerewards(const UniValue& params, bool fHelp)
 {
-    bool fEnable;
+    bool fEnable = false;
     if (params.size() >= 1)
         fEnable = params[0].get_bool();
 
-    if (fHelp || params.size() < 1 || (fEnable && params.size() != 2) || params.size() > 2)
+    if (fHelp || params.size() < 1 || (fEnable && params.size() < 2) || params.size() > 3)
         throw runtime_error(
-            "autocombinerewards true|false ( threshold )\n"
-            "\nWallet will automatically monitor for any coins with value below the threshold amount, and combine them if they reside with the same UCC address\n"
-            "When autocombinerewards runs it will create a transaction, and therefore will be subject to transaction fees.\n"
+            "autocombinerewards true|false ( threshold ) ( frequency )\n"
+            "\nWallet will automatically monitor for UTXOs with values below the threshold amount, "
+            "and combine them into transactions sized to the threshold amount, if they reside with "
+            "the same UCC address.\n"
+            "When autocombinerewards runs it will create a transaction, and therefore will be subject "
+            "to transaction fees.  Transactions will be limited to a full combine of the threshold "
+            "amount unless the transaction fees are zero.\n"
 
             "\nArguments:\n"
             "1. true|false      (boolean, required) Enable auto combine (true) or disable (false)\n"
             "2. threshold       (numeric, optional) Threshold amount (default: 0)\n"
+            "3. frequency       (numeric, optional) Frequency (in blocks) for autocombine to run (default: 15)\n"
             "\nExamples:\n" +
-            HelpExampleCli("autocombinerewards", "true 500") + HelpExampleRpc("autocombinerewards", "true 500"));
+            HelpExampleCli("autocombinerewards", "true 500 15") + HelpExampleRpc("autocombinerewards", "true 500 15"));
 
     CWalletDB walletdb(pwalletMain->strWalletFile);
     CAmount nThreshold = 0;
+    int nBlockFrequency = 15;
 
-    if (fEnable)
+    if (fEnable) {
         nThreshold = params[1].get_int();
+        if (params.size() > 2) {
+            nBlockFrequency = params[2].get_int();
+            if (nBlockFrequency < 1)
+                nBlockFrequency = 1;
+        }
+	}
 
     pwalletMain->fCombineDust = fEnable;
     pwalletMain->nAutoCombineThreshold = nThreshold;
+	pwalletMain->nAutoCombineBlockFrequency = nAutoCombineBlockFrequency;			
 
-    if (!walletdb.WriteAutoCombineSettings(fEnable, nThreshold))
+    if (!walletdb.WriteAutoCombineSettings(fEnable, nThreshold, nBlockFrequency))
         throw runtime_error("Changed settings in wallet but failed to save to database\n");
 
-    return NullUniValue;
+    if (fEnable)
+        return "Auto Combine Rewards Enabled.  Threshold: " << nThreshold << " Frequency: " << nBlockFrequency << " Blocks";
+    else
+        return "Auto Combine Rewards Disabled";
 }
 
 UniValue printMultiSend()

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3302,7 +3302,8 @@ void CWallet::AutoCombineDust()
     }
 
     // If the block height hasn't exceeded our frequency; or is not a multiple of our frequency.
-    if ((nBlockFrequency > chainActive.Tip()->nHeight) || (chainActive.Tip()->nHeight % nBlockFrequency)) {
+    if ((nAutoCombineBlockFrequency > chainActive.Tip()->nHeight) || 
+        (chainActive.Tip()->nHeight % nAutoCombineBlockFrequency)) {
         return;
     }
 	

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3300,6 +3300,11 @@ void CWallet::AutoCombineDust()
         return;
     }
 
+    // If the block height hasn't exceeded our frequency; or is not a multiple of our frequency.
+    if ((nBlockFrequency > chainActive.Tip()->nHeight) || (chainActive.Tip()->nHeight % nBlockFrequency)) {
+        return;
+    }
+	
     map<CBitcoinAddress, vector<COutput> > mapCoinsByAddress = AvailableCoinsByAddress(true, nAutoCombineThreshold * COIN);
 
     //coins are sectioned by address. This combination code only wants to combine inputs that belong to the same address

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2017 The PIVX developers
 // Copyright (c) 2017-2018 The XDNA Core developers
+// Copyright (c) 2018-2019 The United Community Coin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -210,7 +210,7 @@ public:
     //Auto Combine Inputs
     bool fCombineDust;
     CAmount nAutoCombineThreshold;
-	int nAutoCombineBlockFrequency;
+    int nAutoCombineBlockFrequency;
 
     CWallet()
     {

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -3,6 +3,7 @@
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2017 The PIVX developers
 // Copyright (c) 2017-2018 The XDNA Core developers
+// Copyright (c) 2018-2019 The United Community Coin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -209,6 +210,7 @@ public:
     //Auto Combine Inputs
     bool fCombineDust;
     CAmount nAutoCombineThreshold;
+	int nAutoCombineBlockFrequency;
 
     CWallet()
     {
@@ -259,6 +261,7 @@ public:
         //Auto Combine Dust
         fCombineDust = false;
         nAutoCombineThreshold = 0;
+        nAutoCombineBlockFrequency = 15;
     }
 
     bool isMultiSendEnabled()

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2017 The PIVX developers
 // Copyright (c) 2017-2018 The XDNA Core developers
+// Copyright (c) 2018-2019 The United Community Coin Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -223,12 +224,11 @@ bool CWalletDB::EraseMSDisabledAddresses(std::vector<std::string> vDisabledAddre
     }
     return ret;
 }
-bool CWalletDB::WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold)
+bool CWalletDB::WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold, int nBlockFrequency)
 {
     nWalletDBUpdated++;
-    std::pair<bool, CAmount> pSettings;
-    pSettings.first = fEnable;
-    pSettings.second = nCombineThreshold;
+    std::pair<bool, CAmount> enabledMS1(fEnable, nCombineThreshold);
+    std::pair<std::pair<bool, CAmount>,int> pSettings(enabledMS1, nBlockFrequency);
     return Write(std::string("autocombinesettings"), pSettings, true);
 }
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -648,7 +648,7 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             ssValue >> pSettings;
             pwallet->fCombineDust = pSettings.first.first;
             pwallet->nAutoCombineThreshold = pSettings.first.second;
-            pwallet->nBlockFrequency = pSettings.second;
+            pwallet->nAutoCombineBlockFrequency = pSettings.second;
         } else if (strType == "destdata") {
             std::string strAddress, strKey, strValue;
             ssKey >> strAddress;

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -644,10 +644,11 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             ssValue >> strDisabledAddress;
             pwallet->vDisabledAddresses.push_back(strDisabledAddress);
         } else if (strType == "autocombinesettings") {
-            std::pair<bool, CAmount> pSettings;
+            std::pair<std::pair<bool, CAmount>,int> pSettings;
             ssValue >> pSettings;
-            pwallet->fCombineDust = pSettings.first;
-            pwallet->nAutoCombineThreshold = pSettings.second;
+            pwallet->fCombineDust = pSettings.first.first;
+            pwallet->nAutoCombineThreshold = pSettings.first.second;
+            pwallet->nBlockFrequency = pSettings.second;
         } else if (strType == "destdata") {
             std::string strAddress, strKey, strValue;
             ssKey >> strAddress;

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2009-2013 The Bitcoin developers
 // Copyright (c) 2016-2017 The PIVX developers
 // Copyright (c) 2017-2018 The XDNA Core developers
+// Copyright (c) 2018-2019 The United Community Coin Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -115,7 +116,7 @@ public:
     bool WriteMSettings(bool fMultiSendStake, bool fMultiSendMasternode, int nLastMultiSendHeight);
     bool WriteMSDisabledAddresses(std::vector<std::string> vDisabledAddresses);
     bool EraseMSDisabledAddresses(std::vector<std::string> vDisabledAddresses);
-    bool WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold);
+    bool WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold, int nBlockFrequency);
 
     bool WriteDefaultKey(const CPubKey& vchPubKey);
 


### PR DESCRIPTION
Re-Implement old concept of AutoCombineRewardsThresholdTime; which appeared to be a failed attempt at delaying the AutoCombineDust() to occur after X minutes.  That old algorithm was commented out and replaced with a 5 second wait.  This concept also was flawed, in that it was going to be doing a sleep within the ProcessNewBlock() code.  The first attempt was abandoned because it likely was blocking ProcessNewBlock for 15 minutes at a time, and no way to not block, if using the feature, for under a minute.  The workaround (5 seconds) still wasn't desirable, as it would still lock up ProcessNewBlock for the 5 second block.

This new method changes that design from ThresholdTime, to Block Frequency, and defaults to 15 blocks.  Time can be adjusted per implementation, to get a desired minute time based on the block frequency of the coin parameters.  If AutoCombineDust is enabled, it will only check and attempt to combine dust if the block height is a multiple of the Block Frequency.  e.g. if set to 10, then every 10th block it will be executed.  100; then every 100th block.

This can now be tailored by the user, based on their desired dust cleanup threshold, and their expectation of frequency that they will need to clean.