### PR TITLE
Autocombine frequency

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2051,9 +2051,15 @@ UniValue getautocombineinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("autocombine set to <on/off>  ", int(pwalletMain->fCombineDust)));
     if (pwalletMain->fCombineDust) {
         obj.push_back(Pair("autocombine threshold set to <Coin Amount>", 
-                            int(pwalletMain->nAutoCombineThreshold)));
-        obj.push_back(Pair("autocombine block frequency set to ", 
-                            int(pwalletMain->nAutoCombineBlockFrequency)));
+                           int(pwalletMain->nAutoCombineThreshold)));
+        if (0 == pwalletMain->nAutoCombineBlockFrequency) {
+            obj.push_back(Pair("autocombine set to onetime", 
+                               pwalletMain->fCombineDust ? "on next block" : "on startup"));
+        }
+        else {
+            obj.push_back(Pair("autocombine block frequency set to ", 
+                               int(pwalletMain->nAutoCombineBlockFrequency)));
+        }
     }
     
     return obj;
@@ -2061,24 +2067,33 @@ UniValue getautocombineinfo(const UniValue& params, bool fHelp)
 
 UniValue autocombinerewards(const UniValue& params, bool fHelp)
 {
+    string strCommand;
     bool fEnable = false;
-    if (params.size() >= 1)
-        fEnable = params[0].get_bool();
 
+    if (params.size() >= 1) {
+        strCommand = params[0].get_str();
+        if ("onetime" != strCommand)
+            fEnable = params[0].get_bool();
+        else
+            fEnable = true;
+    }
+    
     if (fHelp || params.size() < 1 || (fEnable && params.size() < 2) || params.size() > 3)
         throw runtime_error(
-            "autocombinerewards true|false ( threshold ) ( frequency )\n"
+            "autocombinerewards true|false|onetime ( threshold ) ( frequency )\n"
             "\nWallet will automatically monitor for UTXOs with values below the threshold amount, "
             "and combine them into transactions sized to the threshold amount, if they reside with "
             "the same UCC address.\n"
+            "\nonetime will run the sweep once on the next block.  It will also save this state and "
+            "run again, once, on each restart of the wallet.\n"
             "When autocombinerewards runs it will create a transaction, and therefore will be subject "
             "to transaction fees.  Transactions will be limited to a full combine of the threshold "
             "amount unless the transaction fees are zero.\n"
 
             "\nArguments:\n"
-            "1. true|false      (boolean, required) Enable auto combine (true) or disable (false)\n"
-            "2. threshold       (numeric, optional) Threshold amount (default: 0)\n"
-            "3. frequency       (numeric, optional) Frequency (in blocks) for autocombine to run (default: 15)\n"
+            "1. true|false|onetime (string, required) Enable auto combine (true) or disable (false)\n"
+            "2. threshold          (numeric, required) Threshold amount (default: 0)\n"
+            "3. frequency          (numeric, optional) Frequency (in blocks) for autocombine to run (default: 15)\n"
             "\nExamples:\n" +
             HelpExampleCli("autocombinerewards", "true 500 15") + HelpExampleRpc("autocombinerewards", "true 500 15"));
 
@@ -2093,6 +2108,9 @@ UniValue autocombinerewards(const UniValue& params, bool fHelp)
             if (nBlockFrequency < 1)
                 nBlockFrequency = 1;
         }
+        if ("onetime" == strCommand) {
+            nBlockFrequency = 0;
+        }
     }
 
     pwalletMain->fCombineDust = fEnable;
@@ -2106,9 +2124,10 @@ UniValue autocombinerewards(const UniValue& params, bool fHelp)
     obj.push_back(Pair("autocombine set to <on/off>  ", int(pwalletMain->fCombineDust)));
     if (pwalletMain->fCombineDust) {
         obj.push_back(Pair("autocombine threshold set to <Coin Amount>", 
-                            int(pwalletMain->nAutoCombineThreshold)));
+                           int(pwalletMain->nAutoCombineThreshold)));
         obj.push_back(Pair("autocombine block frequency set to ", 
-                            int(pwalletMain->nAutoCombineBlockFrequency)));
+                           pwalletMain->nAutoCombineBlockFrequency ? 
+                           int(pwalletMain->nAutoCombineBlockFrequency) : "onetime"));
     }
     
     return obj;

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2054,6 +2054,9 @@ UniValue getautocombineinfo(const UniValue& params, bool fHelp)
                            int(pwalletMain->nAutoCombineThreshold)));
         if (0 == pwalletMain->nAutoCombineBlockFrequency) {
             obj.push_back(Pair("autocombine set to one time", "on next block"));
+        } else {
+            obj.push_back(Pair("autocombine block frequency set to ",
+                           int(pwalletMain->nAutoCombineBlockFrequency)));
         }
     }
     else {
@@ -2081,7 +2084,7 @@ UniValue autocombinerewards(const UniValue& params, bool fHelp)
             "\nWallet will automatically monitor for UTXOs with values below the threshold amount, "
             "and combine them into transactions sized to the threshold amount, if they reside with "
             "the same UCC address.\n"
-            "\nA frequency value of \"0\" will run the sweep on the next available block, or once on startup.\n"
+            "\nA frequency value of \"0\" will run the sweep on the next available block, once on every startup.\n"
             "\nWhen autocombinerewards runs it will create a transaction, and therefore will be subject "
             "to transaction fees.  Transactions will be limited to a full combine of the threshold "
             "amount unless the transaction fees are zero.\n"

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2050,15 +2050,17 @@ UniValue getautocombineinfo(const UniValue& params, bool fHelp)
     UniValue obj(UniValue::VOBJ);
     obj.push_back(Pair("autocombine set to <on/off>  ", int(pwalletMain->fCombineDust)));
     if (pwalletMain->fCombineDust) {
-        obj.push_back(Pair("autocombine threshold set to <Coin Amount>", 
+        obj.push_back(Pair("autocombine threshold set to <Coin Amount>",
                            int(pwalletMain->nAutoCombineThreshold)));
         if (0 == pwalletMain->nAutoCombineBlockFrequency) {
-            obj.push_back(Pair("autocombine set to onetime", 
-                               pwalletMain->fCombineDust ? "on next block" : "on startup"));
+            obj.push_back(Pair("autocombine set to one time", "on next block"));
         }
-        else {
-            obj.push_back(Pair("autocombine block frequency set to ", 
-                               int(pwalletMain->nAutoCombineBlockFrequency)));
+    }
+    else {
+        if (0 == pwalletMain->nAutoCombineBlockFrequency) {
+            obj.push_back(Pair("autocombine threshold set to <Coin Amount>",
+                               int(pwalletMain->nAutoCombineThreshold)));
+            obj.push_back(Pair("autocombine set to one time","on startup"));
         }
     }
     
@@ -2067,33 +2069,27 @@ UniValue getautocombineinfo(const UniValue& params, bool fHelp)
 
 UniValue autocombinerewards(const UniValue& params, bool fHelp)
 {
-    string strCommand;
     bool fEnable = false;
 
     if (params.size() >= 1) {
-        strCommand = params[0].get_str();
-        if ("onetime" != strCommand)
-            fEnable = params[0].get_bool();
-        else
-            fEnable = true;
+        fEnable = params[0].get_bool();
     }
     
     if (fHelp || params.size() < 1 || (fEnable && params.size() < 2) || params.size() > 3)
         throw runtime_error(
-            "autocombinerewards true|false|onetime ( threshold ) ( frequency )\n"
+            "autocombinerewards true|false ( threshold ) ( frequency )\n"
             "\nWallet will automatically monitor for UTXOs with values below the threshold amount, "
             "and combine them into transactions sized to the threshold amount, if they reside with "
             "the same UCC address.\n"
-            "\nonetime will run the sweep once on the next block.  It will also save this state and "
-            "run again, once, on each restart of the wallet.\n"
-            "When autocombinerewards runs it will create a transaction, and therefore will be subject "
+            "\nA frequency value of \"0\" will run the sweep on the next available block, or once on startup.\n"
+            "\nWhen autocombinerewards runs it will create a transaction, and therefore will be subject "
             "to transaction fees.  Transactions will be limited to a full combine of the threshold "
             "amount unless the transaction fees are zero.\n"
 
             "\nArguments:\n"
-            "1. true|false|onetime (string, required) Enable auto combine (true) or disable (false)\n"
-            "2. threshold          (numeric, required) Threshold amount (default: 0)\n"
-            "3. frequency          (numeric, optional) Frequency (in blocks) for autocombine to run (default: 15)\n"
+            "1. true|false  (boolean, required) Enable auto combine (true) or disable (false)\n"
+            "2. threshold   (numeric, required) Threshold amount (default: 0)\n"
+            "3. frequency   (numeric, optional) Frequency (in blocks) for autocombine to run (default: 15)\n"
             "\nExamples:\n" +
             HelpExampleCli("autocombinerewards", "true 500 15") + HelpExampleRpc("autocombinerewards", "true 500 15"));
 
@@ -2105,11 +2101,8 @@ UniValue autocombinerewards(const UniValue& params, bool fHelp)
         nThreshold = params[1].get_int();
         if (params.size() > 2) {
             nBlockFrequency = params[2].get_int();
-            if (nBlockFrequency < 1)
+            if (nBlockFrequency < 0)
                 nBlockFrequency = 1;
-        }
-        if ("onetime" == strCommand) {
-            nBlockFrequency = 0;
         }
     }
 
@@ -2125,9 +2118,12 @@ UniValue autocombinerewards(const UniValue& params, bool fHelp)
     if (pwalletMain->fCombineDust) {
         obj.push_back(Pair("autocombine threshold set to <Coin Amount>", 
                            int(pwalletMain->nAutoCombineThreshold)));
-        obj.push_back(Pair("autocombine block frequency set to ", 
-                           pwalletMain->nAutoCombineBlockFrequency ? 
-                           int(pwalletMain->nAutoCombineBlockFrequency) : "onetime"));
+        if (0 == pwalletMain->nAutoCombineBlockFrequency) {
+            obj.push_back(Pair("autocombine block frequency set to ", "one time"));
+        } else {
+            obj.push_back(Pair("autocombine block frequency set to ",
+                           int(pwalletMain->nAutoCombineBlockFrequency)));
+        }
     }
     
     return obj;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3301,10 +3301,16 @@ void CWallet::AutoCombineDust()
         return;
     }
 
-    // If the block height hasn't exceeded our frequency; or is not a multiple of our frequency.
-    if ((nAutoCombineBlockFrequency > chainActive.Tip()->nHeight) || 
-        (chainActive.Tip()->nHeight % nAutoCombineBlockFrequency)) {
-        return;
+    if (0 != nAutoCombineBlockFrequency) {
+        // If the block height hasn't exceeded our frequency; or is not a multiple of our frequency.
+        if ((nAutoCombineBlockFrequency > chainActive.Tip()->nHeight) || 
+            (chainActive.Tip()->nHeight % nAutoCombineBlockFrequency)) {
+            return;
+        }
+    } else {
+        // If nAutoCombineBlockFrequency is 0, it's the special onetime case
+        // so let it rip but turn it off so it doesn't rip again.
+        fCombineDust = 0;
     }
 	
     map<CBitcoinAddress, vector<COutput> > mapCoinsByAddress = AvailableCoinsByAddress(true, nAutoCombineThreshold * COIN);


### PR DESCRIPTION
Added "oneshot" functionality, allowing you to specify a block frequency of "zero", which will run the autocombine on the processing of the next block.  This functionality assumes that someone would be running their wallet infrequently, and therefore is likely to want the one shot to run when they start the wallet again.  As such, the "on" and "frequency 0" is saved in the database, but after it runs, it will be shut off for the duration of the wallet run.

If they do not want it running on startup; they would simply "autocombinerewards false" after it's done it's one shot.

The feature, in it's entirety:

- Defaults to off
- When "on", requires a threshold (in coin count)
- Block frequency defaults to every 15 blocks.  This can changed to every block (resource intensive) or however many blocks one expects their threshold to hit.
- Block frequency of "0" will run the sweep on the next block, and then turn it off until they run it again, or restart their wallet.
- To prevent the one shot to run on startup, they simply need to turn it off after the sweep is complete (when getautocombineinfo returns "on startup" rather than "on next block")

For example:
Suppose a user has 16 tier 1 masternodes.  They can expect to run into problems sending more than 75 coins (630 UTXOs at 0.12 coins per UTXO = 75.6).  This would hit when each of the 16 masternodes has received 4.725 coins (75.6 / 16); which happens after about 39 block rewards (4.725 coins / 0.12 coins per reward = 39.375).  If there are 35 tier one masternodes; you would expect one block every 35 blocks.  35 * 39 = 1378 blocks until you would expect to hit your 4.725 coins across 630 UTXOs.

So, a good setting would be 
`autocombinerewards true 4 700 `

Which will scan your wallet every 700 blocks and combine the dust into 4 coin transactions (or smaller if you can receive zero fee transactions.