### PR TITLE
SeeSaw Updates & Drift changes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -3,7 +3,7 @@
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2017 The PIVX developers
 // Copyright (c) 2017-2018 The XDNA Core developers
-// Copyright (c) 2018-2018 The UCC Core developers
+// Copyright (c) 2018-2019 The UCC Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -178,7 +178,7 @@ public:
         nTargetSpacing = 1 * 60;  // UCC: 1 minute
         nAntiInstamineTime = 720; // 720 blocks with 1 reward for instamine prevention
         nMaturity = 60;
-        nMasternodeCountDrift = 3;
+        nMasternodePercentDrift = 3;
         nMaxMoneyOut = 367452000 * COIN;
 
         nStartMasternodePaymentsBlock = 7001;
@@ -295,7 +295,7 @@ public:
         nTargetSpacing = 1 * 10;  // UCC: 10 seconds
         nLastPOWBlock = 40000;
         nMaturity = 15;
-        nMasternodeCountDrift = 4;
+        nMasternodePercentDrift = 4;
         nModifierUpdateBlock = std::numeric_limits<decltype(nModifierUpdateBlock)>::max();
         nMaxMoneyOut = 1000000000 * COIN;
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -140,7 +140,7 @@ protected:
     int nAntiInstamineTime;
     int nLastPOWBlock;
     int nStartMasternodePaymentsBlock;
-    int nMasternodeCountDrift;
+    int nMasternodePercentDrift;
     int nMaturity;
     int nModifierUpdateBlock;
     CAmount nMaxMoneyOut;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -3,7 +3,7 @@
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2017 The PIVX Core developers
 // Copyright (c) 2017-2018 The XDNA Core developers
-// Copyright (c) 2018-2018 The UCC Core developers
+// Copyright (c) 2018-2019 The UCC Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -89,7 +89,7 @@ public:
     int COINBASE_MATURITY() const { return nMaturity; }
     CAmount MaxMoneyOut() const { return nMaxMoneyOut; }
     /** The masternode count that we will allow the see-saw reward payments to be off by */
-    int MasternodeCountDrift() const { return nMasternodeCountDrift; }
+    int MasternodePercentDrift() const { return nMasternodePercentDrift; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** In the future use NetworkIDString() for RPC fields */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1682,11 +1682,11 @@ CAmount GetSeeSaw(const CAmount& blockValue, int nHeight, bool bDrift)
     }
 
     int64_t nMoneySupply = chainActive.Tip()->nMoneySupply;
+    int64_t mNodeCoins;
 
     mNodeCoins = nMasternodeCountLevel1 * 1000 * COIN;
     mNodeCoins += nMasternodeCountLevel2 * 3000 * COIN;
     mNodeCoins += nMasternodeCountLevel3 * 5000 * COIN;
-    mRawLocked = mNodeCoins;
 
     if (bDrift) {
         int64_t mRawLocked = mNodeCoins;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3190,7 +3190,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
                 return state.DoS(100, error("CheckBlock() : coinbase do not have the dev or fund reward."),
                 REJECT_INVALID, "bad-cb-reward-missing");
 
-            int FoudIndex = -1;
+            int FundIndex = -1;
             int DevIndex = -1;
 
             for (unsigned int indx = 0; indx < block.vtx[0].vout.size(); ++indx) {
@@ -3199,10 +3199,10 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
                 if (tmp_address == DevAddress)
                     DevIndex = indx;
                 if (tmp_address == FundAddress)
-                    FoudIndex = indx;
+                    FundIndex = indx;
             }
 
-            if(FoudIndex == -1 || DevIndex == -1)
+            if(FundIndex == -1 || DevIndex == -1)
                 return state.DoS(100, error("CheckBlock() : coinbase do not have the dev or fund reward (vout)."),
                 REJECT_INVALID, "bad-cb-reward-missing");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1678,7 +1678,6 @@ CAmount GetSeeSaw(const CAmount& blockValue, int nHeight, bool bDrift)
     }
 
     int64_t nMoneySupply = chainActive.Tip()->nMoneySupply;
-    int64_t mNodeCoins, mRawLocked;
 
     mNodeCoins = nMasternodeCountLevel1 * 1000 * COIN;
     mNodeCoins += nMasternodeCountLevel2 * 3000 * COIN;
@@ -1686,16 +1685,19 @@ CAmount GetSeeSaw(const CAmount& blockValue, int nHeight, bool bDrift)
     mRawLocked = mNodeCoins;
 
     if (bDrift) {
-	  // Add drift wiggle room to the calcuation.  
-	  mNodeCoins += (mNodeCoins * ((double)Params().MasternodePercentDrift() / 100));
-          if (fDebug && (nHeight != lastHeight))
-	      LogPrintf("GetSeeSaw(): Adding %d%% to %s locked coins.  Using %s to generate minimum required payment.\n", 
-                        (int)Params().MasternodePercentDrift(), FormatMoney(mRawLocked).c_str(), FormatMoney(mNodeCoins).c_str());
+        int64_t mRawLocked = mNodeCoins;
+        // Add drift wiggle room to the calcuation.  
+        mNodeCoins += (mNodeCoins * ((double)Params().MasternodePercentDrift() / 100));
+        if (fDebug && (nHeight != lastHeight)) {
+            LogPrintf("GetSeeSaw(): Adding %d%% to %s locked coins.  Using %s to generate minimum required payment.\n", 
+                      (int)Params().MasternodePercentDrift(), FormatMoney(mRawLocked).c_str(), FormatMoney(mNodeCoins).c_str());
+        }
     }
 
-    if (fDebug && (nHeight != lastHeight))
+    if (fDebug && (nHeight != lastHeight)) {
         LogPrintf("GetSeeSaw(): Calculating Masternode Reward when Coin Supply is %s and Locked Coins are %s\n", 
                   FormatMoney(nMoneySupply).c_str(), FormatMoney(mNodeCoins).c_str());
+    }
 
     CAmount ret = 0;  // if not POS, we will have strange results; however just leave the warning above and let it go.
 
@@ -1724,11 +1726,12 @@ CAmount GetSeeSaw(const CAmount& blockValue, int nHeight, bool bDrift)
     ** 100 - 0 - 4 = 96; 100 - 76 - 4 = 20
     */
     ret = blockValue * ((double)(100-SeeSawTableIndex-4) / 100);
-    if (fDebug && (nHeight != lastHeight))
+    if (fDebug && (nHeight != lastHeight)) {
         LogPrintf("GetSeeSaw(): Calculated Masternode to receive %s%s of the %s Block Reward\n", 
-		  bDrift ? "at least " : "",
-		  FormatMoney(ret).c_str(),
+                  bDrift ? "at least " : "",
+                  FormatMoney(ret).c_str(),
                   FormatMoney(blockValue).c_str());
+    }
 
     lastHeight = nHeight; // save the height so we don't keep issuing the same messages
     return ret;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3208,7 +3208,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
 
             CAmount block_value = GetBlockValue(nHeight, block.nTime);
 
-            if (block.vtx[0].vout[DevIndex].nValue < block_value * Params().GetDevFee() / 100 || block.vtx[0].vout[FoudIndex].nValue < block_value * Params().GetFundFee() / 100)
+		    
+            if (block.vtx[0].vout[DevIndex].nValue < block_value * Params().GetDevFee() / 100 || block.vtx[0].vout[FundIndex].nValue < block_value * Params().GetFundFee() / 100)
                 return state.DoS(100, error("CheckBlock() : coinbase do not have the enough reward for dev or fund."),
                 REJECT_INVALID, "bad-cb-reward-invalid");
 

--- a/src/main.h
+++ b/src/main.h
@@ -3,6 +3,7 @@
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2017 The PIVX developers
 // Copyright (c) 2017-2018 The XDNA Core developers
+// Copyright (c) 2018-2019 The UCC Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -228,7 +229,7 @@ bool DisconnectBlocksAndReprocess(int blocks);
 
 // ***TODO***
 double ConvertBitsToDouble(unsigned int nBits);
-int64_t GetMasternodePayment(int nHeight, unsigned mnlevel, int64_t blockValue);
+int64_t GetMasternodePayment(int nHeight, unsigned mnlevel, int64_t blockValue, bool bDrift = false);
 
 bool ActivateBestChain(CValidationState& state, CBlock* pblock = NULL);
 CAmount GetBlockValue(int nHeight, uint32_t nTime);

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -347,6 +347,14 @@ bool CMasternodeBlockPayees::IsTransactionValid(const CTransaction& txNew, uint3
 
     CAmount nReward = GetBlockValue(nBlockHeight, nTime);
 
+    if (nBlockHeight > Params().LAST_POW_BLOCK() {
+        // Deduct the payments out so SeeSaw splits the right amount
+        CAmount DevReward = nReward * Params().GetDevFee() / 100;
+        CAmount FundReward = nReward * Params().GetFundFee() / 100;
+        // Be a little careful so we don't accidentally compound the payment fees.
+        nReward = nReward-DevReward-FundReward;
+    }
+    
     std::string strPayeesPossible;
 
     for(const CMasternodePayee& payee : vecPayments) {

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2015-2017 The PIVX developers
 // Copyright (c) 2017-2018 The Bulwark developers
 // Copyright (c) 2017-2018 The XDNA Core developers
+// Copyright (c) 2018-2019 The UCC Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -353,7 +354,7 @@ bool CMasternodeBlockPayees::IsTransactionValid(const CTransaction& txNew, uint3
         if(payee.nVotes < MNPAYMENTS_SIGNATURES_REQUIRED)
             continue;
 
-        auto requiredMasternodePayment = GetMasternodePayment(nBlockHeight, payee.mnlevel, nReward);
+        auto requiredMasternodePayment = GetMasternodePayment(nBlockHeight, payee.mnlevel, nReward, true);
 
         auto payee_out = std::find_if(txNew.vout.cbegin(), txNew.vout.cend(), [&payee, &requiredMasternodePayment](const CTxOut& out){
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -186,7 +186,7 @@ void DumpMasternodes()
             return;
         }
     }
-    LogPrintf("Writting info to mncache.dat...\n");
+    LogPrintf("Writing info to mncache.dat...\n");
     mndb.Write(mnodeman);
 
     LogPrintf("Masternode dump finished  %dms\n", GetTimeMillis() - nStart);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2084,6 +2084,7 @@ UniValue autocombinerewards(const UniValue& params, bool fHelp)
     }
     
     if (fHelp || params.size() < 1 || (fEnable && params.size() < 2) || params.size() > 3)
+        throw runtime_error(
             "autocombinerewards enable ( threshold ) ( frequency )\n"
             "\nWallet will automatically monitor for UTXOs with values below the threshold amount, "
             "and combine them into transactions sized to the threshold amount, if they reside with "


### PR DESCRIPTION
Reworked Masternode Drift to be percent based instead of Masternode Count based, and implemented the checks.  Instead of adding a few masternodes to determine the minimum payment a staker should be paying for consensus approval; it now will add nMasternodePercentDrift to the count of locked coins, to determine the minimum payment.  This should, most of the time, be the same as the actual.  However in situations where the numbers of masternodes that the staker sees is a few masternodes less than what other nodes on the network sees (or masternodes drop off between the time the block is submitted and the block is verified), and that difference is enough to kick it into a different SeeSawTableIndex; the drift algorithm will allow for that block to be written properly.  

Great care should be used when choosing a percentage.  You don't want to guarantee a different table index, otherwise bad actors can constantly short change the masternodes.  with a 3% setting, this (currently) is about 44k added to the locked balance, but only occasionally causes the required masternode payment to be one index less.  Any bad actor that chooses to game this system runs the risk of having their block rejected because they pushed it to the edge and there actually was a difference in masternodes between the block submission and it's validation; in which case they will lose the block and their reward; and thus it is not a profitable game.

A boolean is added to GetMasternodePayment(), and GetSeeSaw() named bDrift.  The default is false; and that is the way it is called during block creation.  During block validation, GetMasternodePayment() is to be called with bDrift set to true; and thus the 3% will be added to the locked coins, to possibly show a lower required payment... to handle different views of the masternode landscape, or changes between block creation and validation. 

The functions can be monitored via debug messages with the string "GetSeeSaw", and are only active when running with -debug enabled.

SeeSaw algorithm has also been fixed after testing, correcting issues where floats less than 1 aren't converted to integer 0 prematurely.

A couple typos were handled as well.