### PR TITLE
Posfixes cs review

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2343,7 +2343,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, uint32_t nTime, unsigne
     if (mapArgs.count("-reservebalance") && !ParseMoney(mapArgs["-reservebalance"], nReserveBalance))
         return error("CreateCoinStake : invalid reserve balance amount");
 
-    if (nBalance > 0 && nBalance <= nReserveBalance)
+    if (nBalance <= nReserveBalance)
         return false;
 
     // presstab HyperStake - Initialize as static and don't update the set on every run of CreateCoinStake() in order to lighten resource use


### PR DESCRIPTION
My notes are kind of cryptic;

CreateNewBlock()
	txNew
	pushed onto block with scriptPubKey and null vin

- 	if not proof of stake

		vout[0] block value fees
		txReward vtx[0]
		vtx[0].vout[0].nValue deducted dev and fund
		FillBlockPayee (vtx[0])
		vtx[0].vout[0].nValue deducts masternode reward.

- 	if proof of stake

		createCoinStake(txCoinStake)
			vout[0]push back null vout
			vin[0] = stake
			vout[1] = stake
			credit = block value.  if > split threshold
			vout[1] = 1/2
			vout[2] = 1/2
			return
		vtx[0].vout[0] = insure empty
		push coinstake to vtx[1]
		if nHeight > 1
		txReward is vtx[1]
		reward_vout = 3 - 1 -> 2 (with split), 2 - 1 -> 1 (with split)
		vout[3] = Dev Fee
		vout[4] = Fund fee
		vout[2] = value - dev & fund
		block_value = value - rewards
		FillBlockPayee
	        	vout[5] mn1
			vout[6] mn2
			vout[7] mn3
		vout[2] = value - masternodepays

	Therefore
vtx[0] = empty
vtx[1]
  vin[0] = stake
  vout[0] = empty
  vout[1] = stake (1/2 input+blockreward)
  vout[2] = stake (1/2 input+blockreward) minus dev fee minus fund fee minus masternode rewards
  vout[3] = dev fee
  vout[4] = fund fee
  vout[5] = mn payment 1
  vout[6] = mn payment 2
  vout[7] = mn payment 3

wallet.cpp
  -     if (nBalance > 0 && nBalance <= nReserveBalance)
	Don't want to continue if nBalance = 0, since we're not staking zerocoins and don't want to waste time with a negative nTargetAmount (or a very large)
  - 
```
    //presstab HyperStake - calculate the total size of our new output including the stake reward so that we can use it to decide whether to split the stake outputs
    if (nCredit / 2 > nStakeSplitThreshold * COIN) {
        txNew.vout[1].nValue = (nCredit / 2 / CENT) * CENT;
        txNew.vout.push_back(CTxOut(nCredit - txNew.vout[1].nValue, txNew.vout[1].scriptPubKey));
    } else {
        txNew.vout[1].nValue = nCredit;
    }
```

  Technically nCredit is the full block amount, not the stake reward; but that's not a big deal if we decrement it properly.
  total value, split in half; pushed back (added to the end of the of the vector)
  e.g. value (2000) + block (2004) / 2 = 1002 pushed to both vout[1] and vout[end].
