### PR TITLE
Mining Cleanup

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -102,7 +102,7 @@ CAmount CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, CAmount 
             payee = GetScriptForDestination(winningNode->pubKeyCollateralAddress.GetID());
         }
 
-        CAmount masternodePayment = GetMasternodePayment(pindexPrev->nHeight, mnlevel, block_value);
+        CAmount masternodePayment = GetMasternodePayment(pindexPrev->nHeight+1, mnlevel, block_value);
 
         if(!masternodePayment)
             continue;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -416,16 +416,6 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
 
         pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(pblock->vtx[0]);
 
-        if (fProofOfStake) {
-            unsigned int nExtraNonce = 0;
-            IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
-            LogPrintf("CPUMiner : proof-of-stake block found %s \n", pblock->GetHash().ToString().c_str());
-            if (!pblock->SignBlock(*pwallet)) {
-                LogPrintf("CreateNewBlock(): Signing new block with UTXO key failed \n");
-                return nullptr;
-            }
-        }
-
         CValidationState state;
         if (!TestBlockValidity(state, *pblock, pindexPrev, false, false)) {
             LogPrintf("CreateNewBlock() : TestBlockValidity failed\n");

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -523,6 +523,8 @@ bool ProcessBlockFound(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
 }
 
 bool fGenerateBitcoins = false;
+bool fMintableCoins = false;
+int nMintableLastCheck = 0;
 
 // ***TODO*** that part changed in bitcoin, we are using a mix with old one here for now
 
@@ -536,11 +538,8 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
     CReserveKey reservekey(pwallet);
     unsigned int nExtraNonce = 0;
 
-    //control the amount of times the client will check for mintable coins
-    static bool fMintableCoins = false;
-    static int nMintableLastCheck = 0;
-
-    if (fProofOfStake && (GetTime() - nMintableLastCheck > 5 * 60)) // 5 minute check time
+    // do an initial check
+    if (fProofOfStake && !nMintableLastCheck)
     {
         nMintableLastCheck = GetTime();
         fMintableCoins = pwallet->MintableCoins();
@@ -549,23 +548,27 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
     while (fGenerateBitcoins || fProofOfStake) {
         if (fProofOfStake) {
             if (chainActive.Tip()->nHeight < Params().LAST_POW_BLOCK()) {
-                MilliSleep(5000);
+                // The last POW block hasn't even been mined yet.
+                MilliSleep(Params().TargetSpacing() * 1000);
                 continue;
+            }
+
+            // Periodically check if we have mintable coins
+            if (GetTime() - nMintableLastCheck > 1 * 60) // 1 minute check time
+            {
+                nMintableLastCheck = GetTime();
+                fMintableCoins = pwallet->MintableCoins();
             }
 
             while (vNodes.empty() || pwallet->IsLocked() || !fMintableCoins || (pwallet->GetBalance() > 0 && nReserveBalance >= pwallet->GetBalance()) || !masternodeSync.IsSynced()) {
                 nLastCoinStakeSearchInterval = 0;
-                // Do a separate 1 minute check here to ensure fMintableCoins is updated
-                if (!fMintableCoins) {
-                    if (GetTime() - nMintableLastCheck > 1 * 60) // 1 minute check time
-                    {
-                        nMintableLastCheck = GetTime();
-                        fMintableCoins = pwallet->MintableCoins();
-                    }
-                }
                 MilliSleep(5000);
-                if (!fGenerateBitcoins && !fProofOfStake)
-                    continue;
+                // recheck if we have mintable coins, while waiting to be stakable.
+                if (GetTime() - nMintableLastCheck > 1 * 60) // 1 minute check time
+                {
+                    nMintableLastCheck = GetTime();
+                    fMintableCoins = pwallet->MintableCoins();
+                }
             }
 
             if (mapHashedBlocks.count(chainActive.Tip()->nHeight)) //search our map of hashed blocks, see if bestblock has been hashed yet
@@ -575,6 +578,13 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
                     MilliSleep(5000);
                     continue;
                 }
+            }
+        } else { // PoW
+            if (chainActive.Tip()->nHeight > Params().LAST_POW_BLOCK()) {
+                // If we're out of the PoW phase, exit the PoW mining threads
+                LogPrintf("BitcoinMiner(): Exiting Proof of Work Mining Thread at height: %d\n",
+                          chainActive.Tip()->nHeight );
+                return;
             }
         }
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -17,17 +17,21 @@ class CWallet;
 
 struct CBlockTemplate;
 
-/** Run the miner threads */
-void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads);
 /** Generate a new block, without valid proof-of-work */
 CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, bool fProofOfStake);
-CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey, CWallet* pwallet, bool fProofOfStake);
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
 /** Check mined block */
 void UpdateTime(CBlockHeader* block, const CBlockIndex* pindexPrev);
 
+#ifdef ENABLE_WALLET
+/** Run the miner threads */
+void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads);
+/** Generate a new block, without valid proof-of-work */
+CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey, CWallet* pwallet, bool fProofOfStake);
+
 void BitcoinMiner(CWallet* pwallet, bool fProofOfStake);
+#endif // ENABLE_WALLET
 
 extern double dHashesPerSec;
 extern int64_t nHPSTimerStart;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2343,7 +2343,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, uint32_t nTime, unsigne
     if (mapArgs.count("-reservebalance") && !ParseMoney(mapArgs["-reservebalance"], nReserveBalance))
         return error("CreateCoinStake : invalid reserve balance amount");
 
-    if (nBalance > 0 && nBalance <= nReserveBalance)
+    if (nBalance <= nReserveBalance)
         return false;
 
     // presstab HyperStake - Initialize as static and don't update the set on every run of CreateCoinStake() in order to lighten resource use


### PR DESCRIPTION
There are two threads running in the wallet; PoS thread (net.cpp::ThreadStakeMinter() and miner.cpp::TreadBitcoinMiner()).  Both sit in a while loop within miner.cpp::BitcoinMiner().    These both independently try to create blocks.

The PoS thread rests dormant:
```
        if (fProofOfStake) {
            if (chainActive.Tip()->nHeight < Params().LAST_POW_BLOCK()) {
                MilliSleep(5000);
                continue;
            }
```

But nothing prevents the PoW thread from continuing after the last PoW block; and therefore it will try to mine a PoW block during the PoS phase, until eventually the block creation fails when testing it's Validity.  A ton of processing that's just wasted time.

This has been changed, and now CreateNewBlockWithKey() will abort if it's being called by the thread in charge of creating the block for the phase that we're not in.  

To further address the extraneous resources; the PoW threads will now be exited after the PoW phase has ended.

Additionally, changes made to the BitcoinMiner worker.

These threads initiate on startup; so the following check made no sense:
```
    if (fProofOfStake && (GetTime() - nMintableLastCheck > 5 * 60)) // 5 minute check time
    {
        nMintableLastCheck = GetTime();
        fMintableCoins = pwallet->MintableCoins();
    }
```
BitcoinMiner() thread is started on startup (< 5 minutes most likely), and there is only one thread and it doesn't get recalled; so nMintableLastCheck will likely always be null.  So don't even bother conditionalizing it.  Since there's checks in the while loop; it will get rechecked after a minute anyway, so just initialize it and be done:

```
    // do an initial check
    if (fProofOfStake && !nMintableLastCheck)
    {
        nMintableLastCheck = GetTime();
        fMintableCoins = pwallet->MintableCoins();
    }
```

Next:  
```
            if (chainActive.Tip()->nHeight < Params().LAST_POW_BLOCK()) {
                MilliSleep(5000);
                continue;
            }
```
The above code holds the PoS miner dormant during the PoW phase.  However restarting every 5 seconds is foolish.  Technically, we could easily let it sit dormant for` (LAST_POW_BLOCK - nHeight) * Target Spacing()`, but rather taking it to a major extreme; cutting it down to sleeping until the next block would make a lot more sense:
```
            if (chainActive.Tip()->nHeight < Params().LAST_POW_BLOCK()) {
                // The last POW block hasn't even been mined yet.
                MilliSleep(Params().TargetSpacing() * 1000);
                continue;
            }
```

In the inner while loop, it checks for mintable coins, if we didn't have mintable coins.  This is flawed in a few ways.  We only check if we have stakeable coins if we didn't when we started up.  We need to be checking if our stakeable coins are no longer stakeable too.  This would need to be done both in the main loop, but also in the inner loop (in case, for example, we are in the inner loop because our wallet is locked, but we have stakeable coins.  You now unlock your wallet and send away your stakeable coins... this will re-check those coins to be stakeable and stay in the loop if not.

Additionally, it would check the mintable at the start of the while loop, not at the end... so the information is actually 5 seconds stale; and the check should actually be after the minsleep, so it's fresh for the next loop.

Finally:
```
                if (!fGenerateBitcoins && !fProofOfStake)
                    continue;
```
This wonderful bit of head scratcher.  First, fProofOfStake is passed in from the caller to BitcoinMiner (depending on which thread this is doing the work for), and doesn't ever change.  So , simply,
```
if (fProofOfStake) {
  if (!ProofOfStake)
}
```
Is just a waste of cycles, as ProofOfStake can never be false inside that section.   Theoretically, if you remove it and now you base on if GenerateBitcoins is false (which is likely is since this is a minting wallet not a mining wallet), the code does a "continue", which just skips the processing of the remaining code in the current loop.  But it's at the end of the loop... so there's nothing to skip with the continue.  So it's a whole lot of op that should be noop... checking a likely "false" and not-ing it, so now it's likely true, which means the machine code now needs to also check fProofOfStake, which always fails, to skip over a 'continue', which doesn't gain you anything anyway if it was ever called.  The code, is a whole lot of nothing.