### PR TITLE
Add cs_main TRY_LOCK to makeBalance

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -755,6 +755,11 @@ bool IsStandardTx(const CTransaction& tx, string& reason)
 
 bool IsFinalTx(const CTransaction& tx, int nBlockHeight, int64_t nBlockTime)
 {
+    TRY_LOCK(cs_main, lockMain);
+    if (!lockMain) {
+       return false;
+    }
+
     AssertLockHeld(cs_main);
     // Time based nLockTime implemented in 0.1.6
     if (tx.nLockTime == 0)
@@ -3706,6 +3711,11 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, CDis
 
 bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex* const pindexPrev, bool fCheckPOW, bool fCheckMerkleRoot)
 {
+    TRY_LOCK(cs_main, lockMain);
+    if (!lockMain) {
+       return false;
+    }
+
     AssertLockHeld(cs_main);
     if (pindexPrev != chainActive.Tip()) {
         LogPrintf("TestBlockValidity(): No longer working on chain tip\n"); return false;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -40,6 +40,9 @@ void BalanceWorker::makeBalance(const bool& watchOnly)
         TRY_LOCK(pwalletMain->cs_wallet, lockWallet);
         if (!lockWallet) return;
         qDebug() << __FUNCTION__ << ": TRY_LOCK(pwalletMain->cs_wallet, lockWallet)";
+        
+        TRY_LOCK(cs_main, lockMain);
+        if (!lockMain) return;
 
         CAmount balance = 0;
         CAmount unconfirmedBalance = 0;
@@ -228,6 +231,9 @@ void WalletModel::refreshClicked()
 //void WalletModel::checkBalanceChanged()
 void WalletModel::checkBalanceChanged(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& anonymizedBalance, const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance)
 {
+    TRY_LOCK(cs_main, lockMain);
+    if (!lockMain) return;
+
     if (cachedBalance != balance || cachedUnconfirmedBalance != unconfirmedBalance || cachedImmatureBalance != immatureBalance ||
         cachedAnonymizedBalance != anonymizedBalance ||
         cachedWatchOnlyBalance != watchOnlyBalance || cachedWatchUnconfBalance != watchUnconfBalance || cachedWatchImmatureBalance != watchImmatureBalance) {


### PR DESCRIPTION
`WalletModel::SendCoins` used to call `checkBalanceChanged()` and that was changed to call makeBalance().  We know `IsTrusted()` needs the cs_main lock.

`checkBalanceChanged()` had a `TRY_LOCK` for cs_main in it; which was removed.  That was called from `pollBalanceChanged` as well as `SendCoins`.  Since `pollBalanceChanged()` did a TRY_LOCK, then called into `checkBalanceChanged()`, which also does a TRY_LOCK, it is presumed that a TRY_LOCK in `makeBalance() will be functional if called from `pollBalanceChanged()`, since it's the same flow as the previous code.

Along those same lines; the cs_main lock was taken out on a full scope of the function; which includes the remaining portions of the `CheckBalanceChanged()` routine.  So we will try for the lock still in `CheckBalanceChanged`

This has not been compile tested yet; let alone run tested