### PR TITLE
Revert MAX_STANDARD_TX_SIZE

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -61,7 +61,7 @@ static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** Default for accepting alerts from the P2P network. */
 static const bool DEFAULT_ALERTS = true;
 /** The maximum size for transactions we're willing to relay/mine */
-static const unsigned int MAX_STANDARD_TX_SIZE = 250000;
+static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE / 50;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */


### PR DESCRIPTION
Due to the consensus checks on MAX_STANDARD_TX_SIZE; increasing it will allow the current software to create the transaction, but only those running the current software will process that transaction.  So the transaction will create a network split between old and new.  To do it right, it needs to be a consensus change on a spork that is invoked when enough of the network has upgraded.  We will revisit this later, correctly, if we feel it truly is necessary.